### PR TITLE
Fix lint warnings "[ValidateDocumentationComments]: change the parame…

### DIFF
--- a/Sources/Core/Helpers/HTTP.swift
+++ b/Sources/Core/Helpers/HTTP.swift
@@ -21,7 +21,7 @@ public struct HTTP {
     /// Download
     /// - Parameters:
     ///   - url: URL
-    ///   - to: Where to save the downloaded data.
+    ///   - destination: Where to save the downloaded data
     ///   - overwrite: overwrite if exists
     ///   - completionHandler: completion handler
     public static func download(url: URL, to destination: URL, overwrite: Bool = true, completionHandler: @escaping (Result<URL, Error>) -> Void) {

--- a/Sources/Core/ManifestRewriter.swift
+++ b/Sources/Core/ManifestRewriter.swift
@@ -18,8 +18,8 @@ public struct ManifestRewriter {
 
     /// Initialize
     /// - Parameters:
-    ///   - fileSystem: file system will be used. default value is `localFileSystem`.
-    ///   - packagePath: The path to the directory containing Pacakge.swift.
+    ///   - fileSystem: file system will be used, default value is `localFileSystem`
+    ///   - packagePath: The path to the directory containing Pacakge.swift
     /// - Throws: `ManifestLoader` or `Process` errors
     public init(fileSystem: FileSystem = localFileSystem, packagePath: AbsolutePath) throws {
         self.fileSystem = fileSystem


### PR DESCRIPTION
…ters of XXXX's documentation to match its parameters"

swift-format lint reports this warnings if parameters doc comments contains period in the middle of items.

I realized that I had to explain it in one sentence and avoid using periods.